### PR TITLE
Adding Resource limits for MongoDB Dev

### DIFF
--- a/abscan/Makefile
+++ b/abscan/Makefile
@@ -19,7 +19,7 @@ help:
 	done
 
 k3d-install: ## Deploys a local K3d cluster for development.
-	@k3d cluster create abscan-dev --agents ${AGENT} --port "${HOSTPORT}:${SERVICEPORT}@loadbalancer" --k3s-arg "--tls-san=${DNSNAME}"@server:*
+	@k3d cluster create abscan-dev --agents ${AGENT} --port "${HOSTPORT}:${SERVICEPORT}@loadbalancer" --k3s-arg "--tls-san=${DNSNAME}@server:*"
 
 k3d-uninstall: ## Deletes the local K3d cluster. DESTRUCTIVE.
 	@k3d cluster delete abscan-dev

--- a/abscan/README.md
+++ b/abscan/README.md
@@ -37,3 +37,6 @@ For managing the development Kubernetes cluster, an optional step is to [install
 ## Troubleshooting
 **Error:** `Bind for 0.0.0.0:80 failed: port is already allocated` <br>
 **Solution:** A K3d deployment or other service using port 80 on your local environment. Stop this service and try again.
+<br><br>
+**Error:** The K3d deployment hangs with the Docker log showing `unknown service runtime.v1alpha2.RuntimeService`. <br>
+**Solution:** Remove any older running K3d clusters and try again.

--- a/abscan/charts/mongodb/default/values.yaml
+++ b/abscan/charts/mongodb/default/values.yaml
@@ -1,3 +1,11 @@
 auth:
   enabled: true
   rootUser: root
+
+resources:
+  limits:
+    memory: "3Gi"
+    cpu: "2000m"
+  requests:
+    memory: "2Gi"
+    cpu: "1000m"


### PR DESCRIPTION
To help prevent MongoDB development environment from crashing a local machine, resource limits were imposed.